### PR TITLE
Fix broken tests from set min, max.

### DIFF
--- a/auxloss/tests/test_aux_power_consumption.py
+++ b/auxloss/tests/test_aux_power_consumption.py
@@ -3,7 +3,7 @@ import os.path
 sys.path.append(os.path.join(sys.path[0], '../../'))
 import csv
 import pytest
-from unittest import mock
+import mock
 import auxloss
 
 budget_file = os.path.join(sys.path[0], '../', 'MSXIV Power Budget.csv')

--- a/displays/SOC_velocity_graph.py
+++ b/displays/SOC_velocity_graph.py
@@ -1,13 +1,21 @@
 import matplotlib.pyplot as plt
 import os.path
 import sys
-sys.path.append('../')
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 from optimization.car_model import Car
 from soc.SoCEstimation import CoulombCounter
 
-def calculateSOCValues(v_profile, e_profile, distance, initial_soc):
-    car_model = Car()
+def calculateSOCValues(v_profile, e_profile, distance, initial_soc, min_speed=None, max_speed=None):
+    if min_speed is not None and max_speed is not None:
+        car_model = Car(speed_min_ms=min_speed, speed_max_ms=max_speed)
+    elif min_speed is not None:
+        car_model = Car(speed_min_ms=min_speed)
+    elif max_speed is not None:
+        car_model = Car(speed_max_ms=max_speed)
+    else:
+        car_model = Car()
+
     soc_est = CoulombCounter()
 
     soc_intervals = [initial_soc]

--- a/displays/SOC_velocity_graph.py
+++ b/displays/SOC_velocity_graph.py
@@ -6,7 +6,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from optimization.car_model import Car
 from soc.SoCEstimation import CoulombCounter
 
-def calculateSOCValues(v_profile, e_profile, distance, initial_soc, min_speed=None, max_speed=None):
+def calculate_SOC_values(v_profile, e_profile, distance, initial_soc, min_speed=None, max_speed=None):
     if min_speed is not None and max_speed is not None:
         car_model = Car(speed_min_ms=min_speed, speed_max_ms=max_speed)
     elif min_speed is not None:
@@ -36,12 +36,12 @@ def calculateSOCValues(v_profile, e_profile, distance, initial_soc, min_speed=No
 
     return soc_intervals
 
-def generateSOCGraph(v_profile, e_profile, distance, initial_soc=1):
+def generate_SOC_graph(v_profile, e_profile, distance, initial_soc=1):
     x_axis = [0]
     for interval_distance in distance:
         x_axis.append(x_axis[len(x_axis) - 1] + interval_distance)
 
-    soc_values = calculateSOCValues(v_profile, e_profile, distance, initial_soc)
+    soc_values = calculate_SOC_values(v_profile, e_profile, distance, initial_soc)
     soc_percentages = [soc * 100 for soc in soc_values]
 
     # for purpose of graphing velocities as step, start at 0

--- a/displays/tests/test_SOC_velocity_graph.py
+++ b/displays/tests/test_SOC_velocity_graph.py
@@ -24,7 +24,7 @@ def test_calculateSOCValues_nonzero_values():
 
     expected_result = [1, 0.9999995851481777, 0.9999991160493323, 0.9999985299598554, 0.9999992236028236, 0.9999994058571505, 0.9999995157405268, 0.9999994937072884]
 
-    assert(expected_result == calculateSOCValues(velocities, elevations, distances, initial_soc))
+    assert(expected_result == calculateSOCValues(velocities, elevations, distances, initial_soc, min_speed=0, max_speed=1000))
 
 def test_calculateSOCValues_initial_soc_non_1():
     velocities = [5, 7, 9, 13, 9.5, 7.5, 5]
@@ -34,7 +34,7 @@ def test_calculateSOCValues_initial_soc_non_1():
 
     expected_result = [0.9, 0.8999995851481777, 0.8999991160493324, 0.8999985299598554, 0.8999992236028236, 0.8999994058571505, 0.8999995157405268, 0.8999994937072884]
 
-    assert(expected_result == calculateSOCValues(velocities, elevations, distances, initial_soc))
+    assert(expected_result == calculateSOCValues(velocities, elevations, distances, initial_soc, min_speed=0, max_speed=1000))
 
 def test_calculateSOCValues_zero_length_inputs():
     with pytest.raises(IndexError):

--- a/displays/tests/test_SOC_velocity_graph.py
+++ b/displays/tests/test_SOC_velocity_graph.py
@@ -3,20 +3,20 @@ import os
 sys.path.append(os.path.join(sys.path[0], '../../'))
 import pytest
 import mock
-from displays.SOC_velocity_graph import calculateSOCValues, generateSOCGraph
+from displays.SOC_velocity_graph import calculate_SOC_values
 from matplotlib.testing.decorators import check_figures_equal
 import matplotlib.pyplot as plt
 
-def test_calculateSOCValues_zero_values():
+def test_calculate_SOC_values_zero_values():
     velocities = [0, 0, 0]
     elevations = [(0, 0), (0, 0), (0, 0)]
     distances = [0, 0, 0]
     initial_soc = 0
 
     with pytest.raises(ZeroDivisionError):
-        calculateSOCValues(velocities, elevations, distances, initial_soc)
+        calculate_SOC_values(velocities, elevations, distances, initial_soc)
 
-def test_calculateSOCValues_nonzero_values():
+def test_calculate_SOC_values_nonzero_values():
     velocities = [5, 7, 9, 13, 9.5, 7.5, 5]
     elevations = [(-1, 100), (1, 100), (3, 100), (3, 100), (1, 100), (1, 100), (1.5, 100)]
     distances = [10000, 10000, 20000, 30000, 30000, 30000, 20000]
@@ -24,9 +24,9 @@ def test_calculateSOCValues_nonzero_values():
 
     expected_result = [1, 0.9999995851481777, 0.9999991160493323, 0.9999985299598554, 0.9999992236028236, 0.9999994058571505, 0.9999995157405268, 0.9999994937072884]
 
-    assert(expected_result == calculateSOCValues(velocities, elevations, distances, initial_soc, min_speed=0, max_speed=1000))
+    assert(expected_result == calculate_SOC_values(velocities, elevations, distances, initial_soc, min_speed=0, max_speed=1000))
 
-def test_calculateSOCValues_initial_soc_non_1():
+def test_calculate_SOC_values_initial_soc_non_1():
     velocities = [5, 7, 9, 13, 9.5, 7.5, 5]
     elevations = [(-1, 100), (1, 100), (3, 100), (3, 100), (1, 100), (1, 100), (1.5, 100)]
     distances = [10000, 10000, 20000, 30000, 30000, 30000, 20000]
@@ -34,18 +34,18 @@ def test_calculateSOCValues_initial_soc_non_1():
 
     expected_result = [0.9, 0.8999995851481777, 0.8999991160493324, 0.8999985299598554, 0.8999992236028236, 0.8999994058571505, 0.8999995157405268, 0.8999994937072884]
 
-    assert(expected_result == calculateSOCValues(velocities, elevations, distances, initial_soc, min_speed=0, max_speed=1000))
+    assert(expected_result == calculate_SOC_values(velocities, elevations, distances, initial_soc, min_speed=0, max_speed=1000))
 
-def test_calculateSOCValues_zero_length_inputs():
+def test_calculate_SOC_values_zero_length_inputs():
     with pytest.raises(IndexError):
-        calculateSOCValues([], [], [], 1)
+        calculate_SOC_values([], [], [], 1)
 
-def test_calculateSOCValues_single_element_inputs():
+def test_calculate_SOC_values_single_element_inputs():
     with mock.patch("soc.SoCEstimation.CoulombCounter.get_soc", return_value=0.9):
         expected_result = [1, 0.9]
-        assert(expected_result == (calculateSOCValues([1], [(1, 1)], [1], 1)))
+        assert(expected_result == (calculate_SOC_values([1], [(1, 1)], [1], 1)))
 
-def test_calculateSOCValues_inconsistent_length_inputs():
+def test_calculate_SOC_values_inconsistent_length_inputs():
     with pytest.raises(IndexError):
-        calculateSOCValues([1, 2, 3], [(1, 1)], [1], 1)
-        calculateSOCValues([1, 2], [(1, 2), (2, 2), (4, 5)], [1, 2], 1)
+        calculate_SOC_values([1, 2, 3], [(1, 1)], [1], 1)
+        calculate_SOC_values([1, 2], [(1, 2), (2, 2), (4, 5)], [1, 2], 1)

--- a/optimization/tests/test_car_model.py
+++ b/optimization/tests/test_car_model.py
@@ -1,22 +1,86 @@
 import sys
 import os.path
-sys.path.append(os.path.dirname(sys.path[0]))
+import pytest
+import mock
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from car_model import Car
-global car
 # Tests to check that the variables are properly set
-car = Car()
 
+@pytest.fixture
+def car_min_0_max_1000():
+    car = Car()
+    car.speed_min_ms = 0
+    car.speed_max_ms = 1000
+    return car
 
-def test_no_velocity():
-    assert(car.force_req(0) == 10.594800000000001)
+@pytest.fixture
+def car_min_15_max_45():
+    car = Car()
+    car.speed_min_ms = 15
+    car.speed_max_ms = 45
+    return car
 
+def test_no_velocity(car_min_0_max_1000, car_min_15_max_45):
+    assert(car_min_0_max_1000.force_req(0) == 10.594800000000001)
+    assert(round(car_min_15_max_45.force_req(0), 3) == 31.267)
 
-def test_10_ms():
-    assert(car.force_req(10) == 19.7823)
+def test_10_ms(car_min_0_max_1000, car_min_15_max_45):
+    assert(car_min_0_max_1000.force_req(10) == 19.7823)
+    assert(round(car_min_15_max_45.force_req(10), 3) == 31.267)
 
+def test_force_req_more_parameters(car_min_0_max_1000, car_min_15_max_45):
+    # doesn't touch limits
+    assert(round(car_min_0_max_1000.force_req(20, vwind=10, v_old=5, theta=0, timestep=30), 3) == 453.282)
+    # doesn't touch limits
+    assert(round(car_min_15_max_45.force_req(20, vwind=10, v_old=16, theta=0, timestep=30), 3) == 189.282)
+    # v_old gets limited, 55 -> 45
+    assert(round(car_min_15_max_45.force_req(20, vwind=10, v_old=55, theta=0, timestep=30), 3) == -506.718)
+    # v_old gets limited, 55 -> 45 and v gets limited 80 -> 45
+    assert(round(car_min_15_max_45.force_req(80, vwind=10, v_old=55, theta=0, timestep=30), 3) == 288.517)
 
-def test_energy_used():
-    assert(car.energy_used([5, 7, 9, 13, 9.5, 7, 5],
+def test_force_req_errors(car_min_0_max_1000):
+    # divide by timestep
+    with pytest.raises(ZeroDivisionError):
+        car_min_0_max_1000.force_req(80, vwind=10, v_old=55, theta=0, timestep=0)
+
+@mock.patch('car_model.Car.force_req', return_value=0)
+def test_max_velocity(mock_force_req, car_min_0_max_1000, car_min_15_max_45):
+    # mock
+    assert(car_min_0_max_1000.force_req(0) == 0)
+    # limits not used
+    assert(car_min_0_max_1000.max_velocity(0) == 3000)
+    # limits used 500 -> 45
+    assert(car_min_15_max_45.max_velocity(500) == 3045)
+    # more parameters, limits 520 -> 45
+    assert(car_min_15_max_45.max_velocity(520, vwind=20, theta=0, timestep=20) == 2045)
+
+def test_energy_used(car_min_0_max_1000, car_min_15_max_45):
+    assert(car_min_0_max_1000.energy_used([5, 7, 9, 13, 9.5, 7, 5],
                            [(-1, 100), (1, 100), (3, 100), (3, 100),
                            (1, 100), (1, 100), (1.5, 100)])
            == 28267.47205752044)
+    
+    # limits all velocities -> 15 m/s
+    # same as making call with [15, 15, 15, 15, 15, 15, 15] as velocity profiles
+    assert(round(car_min_15_max_45.energy_used([5, 7, 9, 13, 9.5, 7, 5],
+                           [(-1, 100), (1, 100), (3, 100), (3, 100),
+                           (1, 100), (1, 100), (1.5, 100)]), 3)
+           == 36414.488)
+
+def test_energy_used_errors(car_min_0_max_1000):
+    with pytest.raises(IndexError):
+        # velocity profiles too long (8 velocity points, 7 elevation points)
+        car_min_0_max_1000.energy_used([5, 7, 9, 13, 9.5, 7, 5, 20], [(-1, 100), (1, 100), (3, 100), (3, 100), (1, 100), (1, 100), (1.5, 100)])
+    
+    # velocity profiles too short (6 velocity points, 7 elevation points)
+    # does NOT raise an exception since we loop based on size of v_profile
+    car_min_0_max_1000.energy_used([5, 7, 9, 13, 9.5, 7], [(-1, 100), (1, 100), (3, 100), (3, 100), (1, 100), (1, 100), (1.5, 100)])
+
+    with pytest.raises(ZeroDivisionError):
+        # divide by dist = e_profile[point][1]
+        car_min_0_max_1000.energy_used([5, 7, 9, 13, 9.5, 7], [(-1, 0), (1, 100), (3, 100), (3, 100), (1, 100), (1, 100), (1.5, 100)])
+    
+    with pytest.raises(ZeroDivisionError):
+        # divide by v_avg = (v_new + v_old) / 2
+        # two consecutive points add to zero
+        car_min_0_max_1000.energy_used([0, 0, 9, 13, 9.5, 7], [(-1, 100), (1, 100), (3, 100), (3, 100), (1, 100), (1, 100), (1.5, 100)])

--- a/soc/tests/test_PackEfficiency.py
+++ b/soc/tests/test_PackEfficiency.py
@@ -2,8 +2,7 @@ import sys
 import os.path
 sys.path.append(os.path.dirname(sys.path[0]))
 from PackEfficiency import PackEfficiency
-from unittest import mock
-
+import mock
 import pytest
 import math
 import cmath


### PR DESCRIPTION
- Auxloss, removed unittest import to default mock module.
- Displays, changed car_model initialization in calculate_SOC_values to include min_speed and max_speed. Changed tests so that a min and max speed is specified. Both tests are not affected by limits.
- Optimization, added many tests. Added fixtures to test min and max limits. Added tests to document errors that will be thrown by car_model methods.
- SOC, removed unittest import, replaced with default mock module. Renamed functions.