### PR TITLE
Initial fit of HI and LO coils, without tests or power draw method.

### DIFF
--- a/optimization/motor_efficiency.py
+++ b/optimization/motor_efficiency.py
@@ -1,0 +1,110 @@
+import numpy as np
+from scipy.optimize import curve_fit
+import matplotlib.pyplot as plt
+import argparse
+
+class LOCoilCurve:
+
+    # from datasheets, removed first (0, 0)
+    efficiency = np.array([0.001, 50.1, 81.8, 87.9, 90.4, 91.9, 92.3, 
+        92.3, 92.4, 92.4, 92.5, 92.5, 91.5, 91.0, 89.5, 87.4])
+
+    torque = np.array([0.001, 0.6, 3.2, 5.3, 7.3, 9.4, 11.4, 15.4, 19.6,
+        23.8, 28.3, 32.6, 36.9, 41.2, 52.1, 62.6])
+
+    def power_draw(self, torque_required_Nm, energy_draw_W, time_s):
+        pass
+
+    def log_func(self, x, a, b):
+        return a + b * np.log(x)
+
+    def linear_func(self, x, m, b):
+        return m * x + b
+
+    def __init__(self):
+
+        self.start_pars, cov = curve_fit(f=self.log_func, xdata=self.torque[:6],
+            ydata=self.efficiency[:6])
+        self.res = self.efficiency[:6] - self.log_func(self.torque[:6], *self.start_pars)
+
+        self.m = round((self.efficiency[-1] - self.efficiency[4]) \
+            / (self.torque[-1] - self.torque[4]), 8)
+        self.b = self.efficiency[-1] - self.m * self.torque[-1]
+
+        np.append(self.res,
+            [self.efficiency[point] - self.linear_func(self.torque[point], self.m, self.b)
+            for point in range(len(self.torque[6:]))])
+
+
+    def graph(self):
+        x_vals = np.linspace(0.001, self.torque[5], 100)
+        y_vals = self.log_func(x_vals, *self.start_pars)
+        plt.plot(x_vals, y_vals)
+
+        x_vals_end = np.linspace(self.torque[5], self.torque[-1], 100)
+        y_vals_end = self.linear_func(x_vals, self.m, self.b)
+        plt.plot(x_vals_end, y_vals_end)
+
+        plt.plot(self.torque, self.efficiency, 'r+')
+        plt.title("LO Coil")
+        plt.show()
+
+class HICoilCurve:
+
+    # from data sheets, removed inital point (0, 0)
+    efficiency = np.array([0.001, 45.7, 78.3, 84.2, 87.2, 88.9, 89.9, 90.7, 
+        91.3, 91.5, 91.8, 91.5, 91.4, 90.9, 89.7, 88.0])
+
+    torque = np.array([0.001, 0.6, 2.7, 4.4, 6.0, 7.9, 9.6, 13.1, 16.7, 
+        20.4, 24.2, 57.9, 31.7, 35.5, 44.9, 54.0])
+
+        
+    def power_draw(self, torque_required_Nm, energy_draw_W, time_s):
+        pass
+
+    def log_func(self, x, a, b):
+        return a + b * np.log(x)
+
+    def linear_func(self, x, m, b):
+        return m * x + b
+
+    def __init__(self):
+
+        self.start_pars, cov = curve_fit(f=self.log_func, xdata=self.torque[:6],
+            ydata=self.efficiency[:6])
+        self.res = self.efficiency[:6] - self.log_func(self.torque[:6], *self.start_pars)
+
+        self.m = round((self.efficiency[-1] - self.efficiency[4]) \
+            / (self.torque[-1] - self.torque[4]), 8)
+        self.b = self.efficiency[-1] - self.m * self.torque[-1]
+
+        np.append(self.res,
+            [self.efficiency[point] - self.linear_func(self.torque[point], self.m, self.b)
+            for point in range(len(self.torque[6:]))])
+
+    def graph(self):
+        x_vals = np.linspace(0.001, self.torque[5], 100)
+        y_vals = self.log_func(x_vals, *self.start_pars)
+        plt.plot(x_vals, y_vals)
+
+        x_vals_end = np.linspace(self.torque[5], self.torque[-1], 100)
+        print(x_vals_end[-1])
+        y_vals_end = self.linear_func(x_vals_end, self.m, self.b)
+        plt.plot(x_vals_end, y_vals_end)
+
+        plt.plot(self.torque, self.efficiency, 'r+')
+        plt.title("HI Coil")
+        plt.show()
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description='See coil fit graphs', default="lo")
+    parser.add_argument('-c', '--coil', help='Select HI or LO coil')
+    args = parser.parse_args()
+
+    if args.coil.lower() == "lo":
+        lo_coil = LOCoilCurve()
+        lo_coil.graph()
+    else:
+        hi_coil = HICoilCurve()
+        hi_coil.graph()

--- a/optimization/motor_efficiency.py
+++ b/optimization/motor_efficiency.py
@@ -5,7 +5,9 @@ import argparse
 
 class LOCoilCurve:
 
-    # from datasheets, removed first (0, 0)
+    # from datasheets
+    # removed first (0, 0) and replaced with (0.001, 0.001)
+    # (because log)
     efficiency = np.array([0.001, 50.1, 81.8, 87.9, 90.4, 91.9, 92.3, 
         92.3, 92.4, 92.4, 92.5, 92.5, 91.5, 91.0, 89.5, 87.4])
 
@@ -22,7 +24,7 @@ class LOCoilCurve:
         return m * x + b
 
     def __init__(self):
-
+        # haven't used covariance
         self.start_pars, cov = curve_fit(f=self.log_func, xdata=self.torque[:6],
             ydata=self.efficiency[:6])
         self.res = self.efficiency[:6] - self.log_func(self.torque[:6], *self.start_pars)
@@ -32,9 +34,9 @@ class LOCoilCurve:
         self.b = self.efficiency[-1] - self.m * self.torque[-1]
 
         np.append(self.res,
-            [self.efficiency[point] - self.linear_func(self.torque[point], self.m, self.b)
+            [self.efficiency[point] 
+            - self.linear_func(self.torque[point], self.m, self.b)
             for point in range(len(self.torque[6:]))])
-
 
     def graph(self):
         x_vals = np.linspace(0.001, self.torque[5], 100)
@@ -51,13 +53,14 @@ class LOCoilCurve:
 
 class HICoilCurve:
 
-    # from data sheets, removed inital point (0, 0)
+    # from data sheets
+    # removed inital point (0, 0) and replaced with (0.001, 0.001)
+    # (because log)
     efficiency = np.array([0.001, 45.7, 78.3, 84.2, 87.2, 88.9, 89.9, 90.7, 
         91.3, 91.5, 91.8, 91.5, 91.4, 90.9, 89.7, 88.0])
 
     torque = np.array([0.001, 0.6, 2.7, 4.4, 6.0, 7.9, 9.6, 13.1, 16.7, 
         20.4, 24.2, 57.9, 31.7, 35.5, 44.9, 54.0])
-
         
     def power_draw(self, torque_required_Nm, energy_draw_W, time_s):
         pass
@@ -69,7 +72,7 @@ class HICoilCurve:
         return m * x + b
 
     def __init__(self):
-
+        # not using covariance
         self.start_pars, cov = curve_fit(f=self.log_func, xdata=self.torque[:6],
             ydata=self.efficiency[:6])
         self.res = self.efficiency[:6] - self.log_func(self.torque[:6], *self.start_pars)
@@ -79,7 +82,8 @@ class HICoilCurve:
         self.b = self.efficiency[-1] - self.m * self.torque[-1]
 
         np.append(self.res,
-            [self.efficiency[point] - self.linear_func(self.torque[point], self.m, self.b)
+            [self.efficiency[point] 
+            - self.linear_func(self.torque[point], self.m, self.b)
             for point in range(len(self.torque[6:]))])
 
     def graph(self):
@@ -88,7 +92,6 @@ class HICoilCurve:
         plt.plot(x_vals, y_vals)
 
         x_vals_end = np.linspace(self.torque[5], self.torque[-1], 100)
-        print(x_vals_end[-1])
         y_vals_end = self.linear_func(x_vals_end, self.m, self.b)
         plt.plot(x_vals_end, y_vals_end)
 
@@ -97,14 +100,15 @@ class HICoilCurve:
         plt.show()
 
 if __name__ == "__main__":
-
-    parser = argparse.ArgumentParser(description='See coil fit graphs', default="lo")
-    parser.add_argument('-c', '--coil', help='Select HI or LO coil')
+    parser = argparse.ArgumentParser(description='See coil fit graphs')
+    parser.add_argument('-c', '--coil', help='Select HI or LO coil', default="LO")
     args = parser.parse_args()
 
-    if args.coil.lower() == "lo":
+    if args.coil.upper() == "LO":
         lo_coil = LOCoilCurve()
         lo_coil.graph()
-    else:
+    elif args.coil.upper() == "HI":
         hi_coil = HICoilCurve()
         hi_coil.graph()
+    else:
+        print("Choose HI or LO please")


### PR DESCRIPTION
Based on Clarke's work in alt_gain.py and Micah's data [here](https://uwmidsun.atlassian.net/wiki/spaces/MECH/pages/1628012551/Interpreting+the+Graphs+From+Nomura).

+ No tests or power draw so far (for future tickets)
+ I fit it pretty visually... Split into a log func (also tried out power, but didn't work quite as nicely) and the linear section. These aren't super accurate, so I was leaning towards using residuals to keep track of error.

![LO Coil](https://user-images.githubusercontent.com/40974372/95662847-e46da680-0b07-11eb-9924-b85b32180dd8.png)
![HI Coil](https://user-images.githubusercontent.com/40974372/95662857-f7807680-0b07-11eb-8803-08014084cafa.png)