### PR TITLE
Change paths for SOC folder testing to match updated soc_deprecated structure

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -46,9 +46,9 @@ jobs:
     # - name: Routemodel directory
     #   run: |
     #     cd routemodel && pytest && cd tests && pytest && cd ../..
-    - name: SOC directory
+    - name: SOC directory - deprecated
       run: |
-        cd soc && pytest && cd tests && pytest && cd ../..
+        cd soc && pytest && cd soc_deprecated/tests && pytest && cd ../../..
     - name: Solar directory
       run: |
         cd solar && pytest && cd tests && pytest && cd ../..


### PR DESCRIPTION
Old structure
strategy > soc > tests 

New structure
strategy > soc > soc_deprecated > tests
* will need to adjust this again once new tests are developed for new SOC model