### PR TITLE
Fix .gitignore since it wasn't ignoring generated Python files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # ignore python generated files 
 **/.
-**/_
+**/_*
 
 # OS generated files #
 ######################


### PR DESCRIPTION
This was only ignoring directories named `_`, but we want it to ignore directories whose name starts with `_`

Can you check if this is happening on your local repo too? @ufshk @mdshiozaki 