### PR TITLE
Adding Map + Marker using leaflet

### DIFF
--- a/displays/dashboard/README.md
+++ b/displays/dashboard/README.md
@@ -4,6 +4,7 @@ Directory for dashboard visualization. WORK IN PROGRESS.
 
 ## Instructions for running
 + pip install `dash` and `dash-boostrap-components`. We will need to add this to requirements.txt as we develop it.
++ pip install `dash-leaflet` (required for map functionality)
 + Run `index.py` file to start server. Should start on [local host at port 8050](http://localhost:8050/)
 
 ## Directory components

--- a/displays/dashboard/route.py
+++ b/displays/dashboard/route.py
@@ -7,6 +7,7 @@ from dash.exceptions import PreventUpdate
 import plotly.graph_objs as go
 import pandas as pd
 
+import dash_leaflet as dl
 import sys
 import os.path
 sys.path.append(os.path.dirname(__file__))
@@ -15,6 +16,18 @@ ELEVATIONS_FILE = os.path.join(sys.path[0], 'assets', 'wsc_elevation.csv')
 from application import dash_app, app
 
 TEST_DATA = pd.read_csv(ELEVATIONS_FILE, usecols=['Distance', 'Elevation (m)'], index_col='Distance', squeeze=True)
+
+map = dbc.Col([
+    dbc.Card([
+        dbc.CardBody([
+            dl.Map(
+                center=[39, -98],       
+                zoom = 4,
+                children = [dl.TileLayer(), dl.Marker(position=[39, -98])],
+            style={'width': '100%', 'height': '500px'})
+        ])
+    ], className='pretty_container')
+])
 
 graph1 = dbc.Col([
     dbc.Card([
@@ -52,6 +65,7 @@ graph3 = dbc.Col([
 ])
 
 layout = html.Div([
+    dbc.Row([map], no_gutters=True),
     dbc.Row([graph1, graph2], no_gutters=True),
     dbc.Row([graph3], no_gutters=True)
 ])


### PR DESCRIPTION
+ Added map component in route.py
+ Centered around USA + Added Marker

[Jira Link (STRAT-140)](https://uwmidsun.atlassian.net/jira/software/projects/STRAT/boards/12?selectedIssue=STRAT-140)

You'll need to pip install dash-leaflet for it to run (should we add it to requirements.txt?)

We're still trying to see if we can get the maps to work offline (as discussed last stand-up). Leaflet doesn't seem to offer any kind of caching (by default at least).
+ One theoretical solution to get offline maps to run is to essentially set up a local web server that serves the map to DASH. 
+ Another is to use a plugin that does this caching for us, using an external plugin like [this: ](https://github.com/MazeMap/Leaflet.TileLayer.PouchDBCached), but most plugins like these are meant to be used for Leaflet on React, and not dash-leaflet.