### PR TITLE
Change secrets to dotenv based instead of config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@ Thumbs.db
 .python-version
 
 # for API keys
-**/config.py
+**/.env

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ mock==4.0.3
 plotly==4.14.3
 dash_bootstrap_components==0.11.3
 scikit_learn==0.24.1
+python-dotenv

--- a/routemodel/data_retrieval/common.py
+++ b/routemodel/data_retrieval/common.py
@@ -1,10 +1,13 @@
 import requests
 import sys
 import os.path
+from dotenv import load_dotenv
 
 sys.path.append(os.path.dirname(__file__))
 
-from config import BASE_URL, API_KEY
+load_dotenv()
+BING_API_KEY = os.environ.get("BING_API_KEY")
+BASE_URL = 'https://dev.virtualearth.net/REST/v1/'
 
 # common getter for all files
 def get_API_data(query: str):
@@ -13,7 +16,7 @@ def get_API_data(query: str):
     #return: a JSON response from API
     """
     url = BASE_URL + query
-    url += '&key={}'.format(API_KEY)
+    url += '&key={}'.format(BING_API_KEY)
      # get and return response
     try:
         response = requests.get(url)

--- a/routemodel/data_retrieval/config_example.py
+++ b/routemodel/data_retrieval/config_example.py
@@ -1,7 +1,0 @@
-# Instructions: Create "config.py" file in this folder
-# Add API_KEY as shown
-# Add BASE_URL as shown
-# elevations.py, routes.py, and speedlimits.py should be passing pytest once 
-# done! Make sure config.py is never being pushed up.
-API_KEY = ''
-BASE_URL = 'https://dev.virtualearth.net/REST/v1/'

--- a/routemodel/data_retrieval/get_weather.py
+++ b/routemodel/data_retrieval/get_weather.py
@@ -4,8 +4,11 @@ sys.path.append(os.path.dirname(__file__))
 import requests
 import csv
 import json
+from dotenv import load_dotenv
 
-from config import WEATHER_API_KEY
+load_dotenv()
+WEATHER_API_KEY = os.environ.get("WEATHER_API_KEY")
+
 ONE_CALL_BASE = 'https://api.openweathermap.org/data/2.5/onecall?'
 PATH = os.path.join(os.path.dirname(__file__), '..', 'routes\ASC2021\ASC2021_draft.csv')
 


### PR DESCRIPTION
Just another way to storing secrets, do you like it better? It means we just send around the `.env` file to whoever needs it, and it would get placed as `routemodel/data_retrieval/.env`